### PR TITLE
3/1 1/92p

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 db/
+*.txt

--- a/chapter3/asyncConsistentRead.js
+++ b/chapter3/asyncConsistentRead.js
@@ -1,0 +1,16 @@
+import { readFile } from "fs";
+
+const cache = new Map();
+
+function consistentReadAsync(filename, callback) {
+  if (cache.has(filename)) {
+    process.nextTick(() => callback(cache.get(filename)));
+  } else {
+    readFile(filename, "utf8", (err, data) => {
+      cache.set(filename, data);
+      callback(data);
+    });
+  }
+}
+
+

--- a/chapter3/inconsistentRead.js
+++ b/chapter3/inconsistentRead.js
@@ -1,0 +1,35 @@
+import * as fs from "fs";
+const cache = new Map();
+function inconsistentRead(filename, cb) {
+  if (cache.has(filename)) {
+    //동기적으로 호출됨
+    cb(cache.get(filename));
+  } else {
+    //비동기 함수
+    fs.readFile(filename, "utf8", (err, data) => {
+      cache.set(filename, data);
+      cb(data);
+    });
+  }
+}
+
+function createFileReader(filename) {
+  const listeners = [];
+  inconsistentRead(filename, (value) => {
+    listeners.forEach((listener) => listener(value));
+  });
+
+  return {
+    onDataReady: (listener) => listeners.push(listener),
+  };
+}
+
+const reader1 = createFileReader("data.txt");
+reader1.onDataReady((data) => {
+  console.log(`First call data: ${data}`);
+});
+
+const reader2 = createFileReader("data.txt");
+reader2.onDataReady((data) => {
+  console.log(`Second call data: ${data}`);
+});

--- a/chapter3/package.json
+++ b/chapter3/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "chapter8",
+  "version": "1.0.0",
+  "description": "",
+  "main": "safe-calculator.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module"
+}

--- a/chapter3/syncConsistentRead.js
+++ b/chapter3/syncConsistentRead.js
@@ -1,0 +1,15 @@
+import { readFileSync } from "fs";
+
+const cache = new Map();
+
+function consistentReadSync(filename) {
+  if (cache.has(filename)) {
+    if (cache.has(filename)) {
+      return cache.get(filename);
+    } else {
+      const data = readFileSync(filename, "utf8");
+      cache.set(filename, data);
+      return data;
+    }
+  }
+}


### PR DESCRIPTION
# 3. 콜백과 이벤트
## 3-1. 콜백 패턴
### 3-1-1. 연속 전달 방식
Javascript에서 콜백은 다른 함수에 인자로 전달되는 함수이다 
작업이 완료되면 작업 결과를 가지고 호출된다 
함수형 프로그래밍에서 이런식으로 결과를 전달하는 바익을 연속 전달 방식 (CPS: continuation-passing style)이라고 한다. 

#### 동기식 연속 전달 방식
```
function add(a, b, callback) {
  callback(a+b)
}
```
- 동기식으로 콜백함수를 전달하는 방식이다. 
- 이 함수는 내부의 콜백 함수의 작업이 완료되었을 때 종료된다.

#### 비동기식 연속 전달 방식 
```
function additionAsync(a, b, callback) {
  setTimeout(() => callback(a + b), 100) 
}
```
- setTimeout()으로 이벤트 큐에 콜백 함수를 추가하고, 즉시 리턴한다. 
- 이 함수는 콜백 함수가 실행되기 전에 종료된다.

### 3-1-2. 동기? 비동기?

일관성 없는 비동기 함수의 위험성
#### 예측할 수 없는 함수
```
import * as fs from "fs";
const cache = new Map();
function inconsistentRead(filename, cb) {
  if (cache.has(filename)) {
    //동기적으로 호출됨
    cb(cache.get(filename));
  } else {
    //비동기 함수
    fs.readFile(filename, "utf8", (err, data) => {
      cache.set(filename, data);
      cb(data);
    });
  }
}

function createFileReader(filename) {
  const listeners = [];
  inconsistentRead(filename, (value) => {
    listeners.forEach((listener) => listener(value));
  });

  return {
    onDataReady: (listener) => listeners.push(listener),
  };
}

const reader1 = createFileReader("data.txt");
reader1.onDataReady((data) => {
  console.log(`First call data: ${data}`);
});

const reader2 = createFileReader("data.txt");
reader2.onDataReady((data) => {
  console.log(`Second call data: ${data}`);
});
```
- inconsistentRead 함수는 캐시가 있을 때는 동기적으로, 없을 때는 비동기적으로 동작한다.
- 이 때문에 예측할 수 없는 동작이 일어난다.

1. 첫 호출시, 즉 캐시가 없을 때
- reader1 이 등록될 때는 캐시가 없는 상태이기 때문에 fs.readfile이 호출된다.
이 함수는 즉시 반환되고 파일 읽기는 백그라운드에서 계속된다.
- createFileReader는 onDataReady 메서드를 가진 객체를 반환한다. 이 시점에서 파일 읽기는 아직 완료되지 않았다.
- reader1.onDataReady(callback)이 호출된다.

2. 두번째 호출시, 즉 캐시가 있을 때
- reader2를 반환하는 createFileReader가 호출된다
- 역시 listener는 비어있는 상태로 inconsistentRead가 호출된다
- 이번에는 캐시에 값이 있으므로 동기적으로 콜백함수가 호출된다.
- 그런데 콜백함수 즉 listner는 reader2가 반환된 이후에 추가된다.
그렇기 때문에 Second call~은 실행되지 않는다.

그런데 어째서인지, 이 코드를 실행해보면 Second call~도 찍힌다..
이유를 모르겠다.

#### 해결
어떤 경우에도 동기, 또는 비동기로 작동하도록 바꾼다
1. 동기로 바꾸기
- 동기 방식으로 바꾸는 경우, 이벤트 루프를 블록하고 동시 요청을 보류하게 된다
- 이는 JavaScript의 동시성 모델을 깨트려서 전체 애플리케이션의 속도를 떨어트린다.
- 제한된 수의 정적 파일로 작업할 경우에는 consistentReadSync()를 사용하는 것이 이벤트 루프에 큰 영향을 미치지 않지만,
한번이라도 큰파일을 읽는 경우에는 얘기가 달라진다. (오랜 시간동안 블록되게 됨))
- Node.js에서 동기 I/O를 사용하는 것은 많은 경우에 권장되지 않는다.
  하지만 어떤 경우에는 가장 쉽고 효율적인 해결이 되기도 한다
  - 환경변수 초기화 할 때 처럼

2. 비동기로 바꾸기
- 동기 콜백 호출이 동일한 이벤트 루프 사이클에서 즉시 시행되는 대신,
'가까운 미래'에 실행되도록 예약 한다
- Node.js에서는 process.nextTick()을 사용하여 이 작업을 수행할 수 있다.
- process.nextTick()은 현재 진행중인 작업의 완료 시점 뒤로 함수의 실행을지연시킨다.
  콜백을 인수로 취하여 대기중인 I/O 이벤트의 대기열의 앞으로 밀어 넣고 즉시 반환한다.
- 이렇게 하면 현재 진행중인 작업이 제어를 이벤트 루프로 넘기는 즉시 콜백이 실행된다.

- 코드의 실행을 지연시키는 또 다른 API는 setImmediate()이다.
precess.nextTick()과 목적은 유사하지만 그 의미는 크게 다르다.
process.nextTick()으로 지연된 콜백은 마이크로 태스크라 불리며,
현재의 작업이 완료된 후 바로 실행되며 다른 I/O이벤트가 발생하기 전에 실행된다.
- setTimmediate()는 이미 큐에 있는 I/O 이벤트들의 뒤에 대기하게 된다.

-process.nextTick()은 이미 예정된 I/O 보다 먼저 실행되기 때문에,
재귀 호출과 같은 특정 상황에서 I/O 기아(starvation)을 발생시킬 수 있다.
setImmediate()에서는 이런 일이 절대로 일어나지 않는다.

-setTimeout(callback, 0)은 setImmediate()와 비슷한 동작을 한다.
하지만 특정 상황에서는 setImmediate()로 예약된 콜백이
setTimeout(callback, 0)으로 예약된 것보다 빨리 실행된다.
이유는 이벤트 루프가 모든 콜백을 각기 다른 단계에서 실행시키기 때문이다.
1. setTimeout()은 I/O 콜백 전에 실행된다.
2. setTimeout() 콜백 안에서 또는 I/O 콜백 안에서 또는 이 두 단계 이후
   큐에 들어가는 마이크로 태스크 안에서 setImmediate()로 작업을 넣게 되면,
   현재 단계 바로 이후 단계에서 콜백이 실행된다.
   setTimeout() 콜백은 이벤트 루프의 다음 사이클을 기다려야 한다.


